### PR TITLE
Use gobject-introspection to generate VAPI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,32 +46,34 @@ mconnect_SOURCES = src/main.vala \
 		   src/mconn-crypt.h
 
 mconnect_LDADD = $(MCONNECT_LIBS)
-
 mconnect_CFLAGS = $(MCONNECT_CFLAGS) -Isrc
 
-test_mconn_crypt_SOURCES = test/mconn-crypt-test.c \
-			   src/mconn-crypt.c \
-			   src/mconn-crypt.h
+noinst_LTLIBRARIES = libmconn-crypt.la
+libmconn_crypt_la_SOURCES = src/mconn-crypt.c \
+			    src/mconn-crypt.h
+libmconn_crypt_la_CFLAGS = $(MCONNECT_CFLAGS)
+libmconn_crypt_la_LIBADD = $(MCONNECT_LIBS)
 
-test_mconn_crypt_LDADD = $(MCONNECT_LIBS)
+test_mconn_crypt_SOURCES = test/mconn-crypt-test.c
+test_mconn_crypt_LDADD = $(MCONNECT_LIBS) libmconn-crypt.la
 test_mconn_crypt_CFLAGS = $(MCONNECT_CFLAGS) -Isrc
 
-test_mconn_crypt_vala_SOURCES = test/mconn-crypt-vala-test.vala \
-				src/mconn-crypt.c \
-				src/mconn-crypt.h
-test_mconn_crypt_vala_LDADD = $(MCONNECT_LIBS)
+test_mconn_crypt_vala_SOURCES = test/mconn-crypt-vala-test.vala
+test_mconn_crypt_vala_LDADD = $(MCONNECT_LIBS) libmconn-crypt.la
 test_mconn_crypt_vala_CFLAGS = $(MCONNECT_CFLAGS) -Isrc -I.
 
 VALAFLAGS = $(MCONNECT_VALAFLAGS) --vapidir=. --pkg=mconn-crypt
 
-mconn-crypt.gi: src/mconn-crypt.h
+mconn-crypt.gir: libmconn-crypt.la
 	rm -f $@
-	$(GEN_INTROSPECT) -n MConn \
-		$< $(filter -I%,$(MCONNECT_CFLAGS)) > $@
+	$(G_IR_SCANNER) src/mconn-crypt.[ch] $(MCONNECT_CFLAGS) \
+			--include=GObject-2.0 \
+			--namespace=MConn --library $< \
+			--output=$@
 
-mconn-crypt.vapi: mconn-crypt.gi
+mconn-crypt.vapi: mconn-crypt.gir
 	rm -f $@
-	vapigen --library mconn-crypt $<
+	$(VALA_API_GEN) --library mconn-crypt $<
 
 # configure will expand bindir to ${exec_prefix}/bin, we want the
 # whole thing, that's why mconnect.desktop is generated here and not
@@ -87,7 +89,7 @@ git-source-dist:
 	git archive --prefix=mconnect-$${gitsha}/ $(REV) | \
 		gzip -c > mconnect-$${gitsha}.tar.gz
 
-BUILT_SOURCES = mconn-crypt.vapi mconn-crypt.gi mconnect.desktop
+BUILT_SOURCES = mconn-crypt.vapi mconn-crypt.gir mconnect.desktop
 
 CLEANFILES = $(BUILT_SOURCES)
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ with usable results.
 Build dependencies (using package names as found in Fedora):
 
 - vala
-- vala-devel
 - glib2-devel
+- gobject-introspection-devel
 - libgee-devel
 - json-glib
 - openssl-devel

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,7 @@ AC_INIT([mconnect], [0.1.0], [maciek.borzecki@gmail.com])
 AC_CONFIG_SRCDIR([src/main.vala])
 AC_CONFIG_AUX_DIR([.])
 AC_PROG_MAKE_SET
+AM_PROG_LIBTOOL
 AM_INIT_AUTOMAKE([tar-pax foreign subdir-objects])
 AM_SILENT_RULES([yes])
 
@@ -41,18 +42,23 @@ AC_SUBST(MCONNECT_VALAFLAGS, ["--pkg=json-glib-1.0 --pkg=gee-0.8 --pkg=libnotify
 # AC_SUBST(MCONNECT_VALAFLAGS, [--pkg=json-glib-1.0 --pkg=gee-0.8])
 PKG_CHECK_MODULES(MCONNECT, [glib-2.0,
                              gobject-2.0,
+                             gobject-introspection-1.0
                              gio-2.0,
                              gio-unix-2.0,
                              json-glib-1.0,
                              gee-0.8,
                              libcrypto
-                             libvala-0.26
                              libnotify
                              ])
 AC_SUBST(MCONNECT_CFLAGS)
 AC_SUBST(MCONNECT_LIBS)
 
-AC_SUBST(GEN_INTROSPECT,$($PKG_CONFIG --variable=gen_introspect libvala-0.26))
+AC_SUBST(G_IR_SCANNER,$($PKG_CONFIG gobject-introspection-1.0 --variable=g_ir_scanner))
+
+AC_PATH_PROG([VALA_API_GEN], [vapigen])
+if test -z "$VALA_API_GEN"; then
+  AC_MSG_ERROR([vapigen is needed])
+fi
 
 # Files to generate
 AC_CONFIG_FILES([Makefile])

--- a/src/mconn-crypt.h
+++ b/src/mconn-crypt.h
@@ -84,7 +84,7 @@ MConnCrypt *m_conn_crypt_ref(MConnCrypt *crypt);
  * @data: (type GBytes): data
  * @error: return location for a GError or NULL
  *
- * Returns: (transfer full): a new #GBytes with decoded data
+ * Returns: (transfer full): a new #GByteArray with decoded data
  */
 GByteArray * m_conn_crypt_decrypt(MConnCrypt *crypt, GBytes *data, GError **error);
 


### PR DESCRIPTION
It's better to use [GObjectIntrospection](https://wiki.gnome.org/action/show/Projects/GObjectIntrospection) to generate vapi files, so you can get rid of the dependency on vala-dev (which is specific to a version) and get more accurate bindings.