### PR TITLE
Fixed compile-time check error by removing unnecessary default values…

### DIFF
--- a/src/mconnect/device-proxy.vala
+++ b/src/mconnect/device-proxy.vala
@@ -30,7 +30,6 @@ class DeviceDBusProxy : Object {
         }
         private set {
         }
-        default = "";
     }
     public string name {
         get {
@@ -38,7 +37,6 @@ class DeviceDBusProxy : Object {
         }
         private set {
         }
-        default = "";
     }
     public string device_type {
         get {
@@ -46,7 +44,6 @@ class DeviceDBusProxy : Object {
         }
         private set {
         }
-        default = "";
     }
     public uint protocol_version {
         get {
@@ -54,7 +51,6 @@ class DeviceDBusProxy : Object {
         }
         private set {
         }
-        default = 5;
     }
     public string address {
         get; private set; default = "";
@@ -66,7 +62,6 @@ class DeviceDBusProxy : Object {
         }
         private set {
         }
-        default = false;
     }
     public bool allowed {
         get {
@@ -74,7 +69,6 @@ class DeviceDBusProxy : Object {
         }
         private set {
         }
-        default = false;
     }
     public bool is_active {
         get {
@@ -82,7 +76,6 @@ class DeviceDBusProxy : Object {
         }
         private set {
         }
-        default = false;
     }
     public bool is_connected {
         get; private set; default = false;


### PR DESCRIPTION
… for non-auto-implemented class properties.

Due to [Bug 795225 - Report an error when initializing not auto properties](https://bugzilla.gnome.org/show_bug.cgi?id=795225) and [its resolution](https://github.com/GNOME/vala/commit/0d396f7daaf34596b159380b8ee2a57799ac9336), class properties are now prohibited from coincidentally having:

- non-auto-implemented property accessors (i.e. a custom getter and/or setter); and
- a default value.

If either accessor is custom-implemented, the default value previously had no effect. This bug fix implements a compile-time check to disallow default values for properties with custom-implemented getter and/or setter blocks.

My proposed fix for mconnect is simply to remove the default values where they already have no effect in these such properties.