### PR TITLE
clipboard: Add incoming clipboard support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,7 @@ mconnect_src = [
 	'src/mconnect/packethandlers-proxy.vala',
 	'src/mconnect/notification.vala',
 	'src/mconnect/battery.vala',
+	'src/mconnect/clipboard.vala',
 	'src/mconnect/battery-proxy.vala',
 	'src/mconnect/telephony.vala',
 	'src/mconnect/telephony-proxy.vala',

--- a/src/mconnect/clipboard.vala
+++ b/src/mconnect/clipboard.vala
@@ -1,0 +1,57 @@
+/**
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * AUTHORS
+ * James Westman <james@flyingpimonster.net>
+ */
+
+class ClipboardHandler : Object, PacketHandlerInterface {
+    public const string CLIPBOARD = "kdeconnect.clipboard";
+
+    public string get_pkt_type () {
+        return CLIPBOARD;
+    }
+
+    private ClipboardHandler () {
+    }
+
+    public static ClipboardHandler instance () {
+        return new ClipboardHandler ();
+    }
+
+    public void use_device (Device dev) {
+        debug ("use device %s for clipboard", dev.to_string ());
+        dev.message.connect (this.message);
+    }
+
+    public void release_device (Device dev) {
+        debug ("release device %s", dev.to_string ());
+        dev.message.disconnect (this.message);
+    }
+
+    public void message (Device dev, Packet pkt) {
+        if (pkt.pkt_type != CLIPBOARD) {
+            return;
+        }
+
+        var content = pkt.body.get_string_member ("content");
+        debug ("clipboard content: '%s'", content);
+
+        var display = Gdk.Display.get_default ();
+        if (display != null) {
+            var cb = Gtk.Clipboard.get_default (display);
+            cb.set_text (content, -1);
+        }
+    }
+}

--- a/src/mconnect/packethandlers.vala
+++ b/src/mconnect/packethandlers.vala
@@ -39,6 +39,7 @@ class PacketHandlers : Object {
 
         var notification = NotificationHandler.instance ();
         var battery = BatteryHandler.instance ();
+        var clipboard = ClipboardHandler.instance ();
         var telephony = TelephonyHandler.instance ();
         var mousepad = MousepadHandler.instance ();
         var ping = PingHandler.instance ();
@@ -47,6 +48,7 @@ class PacketHandlers : Object {
 
         hnd.@set (notification.get_pkt_type (), notification);
         hnd.@set (battery.get_pkt_type (), battery);
+        hnd.@set (clipboard.get_pkt_type (), clipboard);
         hnd.@set (telephony.get_pkt_type (), telephony);
         hnd.@set (mousepad.get_pkt_type (), mousepad);
         hnd.@set (ping.get_pkt_type (), ping);


### PR DESCRIPTION
Add support for incoming kdeconnect.clipboard messages. When you copy text on a paired device, it will be pasted to the clipboard on the local device.

Note that this is separate from the text sharing feature. Most notably, I've decided not to display a notification when the clipboard is synced, since that could get annoying.