### PR TITLE
Fixes core dumps when mpris is found.

### DIFF
--- a/src/mconnect/mpris.vala
+++ b/src/mconnect/mpris.vala
@@ -326,15 +326,15 @@ class MprisHandler : Object, PacketHandlerInterface {
         }
         if (prop.can_go_next != null) {
             builder.set_member_name ("canGoNext");
-            builder.add_boolean_value (prop.can_pause);
+            builder.add_boolean_value (prop.can_go_next);
         }
         if (prop.can_go_previous != null) {
             builder.set_member_name ("canGoPrevious");
-            builder.add_boolean_value (prop.can_pause);
+            builder.add_boolean_value (prop.can_go_previous);
         }
         if (prop.can_seek != null) {
             builder.set_member_name ("canSeek");
-            builder.add_boolean_value (prop.can_pause);
+            builder.add_boolean_value (prop.can_seek);
         }
         builder.set_member_name ("pos");
         builder.add_int_value (prop.position);


### PR DESCRIPTION
This fixes #55, at least for the segfault related to mpris that I was able to track down.  Since that's the only case I've been able to replicate, I'd suggest this patch closes #55.