### PR TITLE
Added battery command and fixed segfault at add_player() when mpris player does not respond.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,7 @@ mconnectctl_src = [
   'src/mconnectctl/main.vala',
   'src/mconnectctl/device-manager-iface.vala',
   'src/mconnectctl/device-iface.vala',
+  'src/mconnectctl/battery-iface.vala',
   'src/mconnectctl/share-iface.vala',
   'src/mconnectctl/telephony-iface.vala',
 ]

--- a/src/mconnect/mpris.vala
+++ b/src/mconnect/mpris.vala
@@ -396,7 +396,12 @@ class MprisHandler : Object, PacketHandlerInterface {
             MprisProxy mpris = Bus.get_proxy_sync (BusType.SESSION,
                                                    bus_name,
                                                    "/org/mpris/MediaPlayer2");
-            player_list.insert (mpris.identity, bus_name);
+            debug(mpris.identity);
+            if(mpris.identity == null){
+                warning ("failed to connect to mpris player");
+            }else{
+                player_list.insert (mpris.identity, bus_name);
+            }
         } catch (Error e) {
             warning ("failed to connect to mpris player: %s", e.message);
         }

--- a/src/mconnect/mpris.vala
+++ b/src/mconnect/mpris.vala
@@ -326,15 +326,15 @@ class MprisHandler : Object, PacketHandlerInterface {
         }
         if (prop.can_go_next != null) {
             builder.set_member_name ("canGoNext");
-            builder.add_boolean_value (prop.can_pause);
+            builder.add_boolean_value (prop.can_go_next);
         }
         if (prop.can_go_previous != null) {
             builder.set_member_name ("canGoPrevious");
-            builder.add_boolean_value (prop.can_pause);
+            builder.add_boolean_value (prop.can_go_previous);
         }
         if (prop.can_seek != null) {
             builder.set_member_name ("canSeek");
-            builder.add_boolean_value (prop.can_pause);
+            builder.add_boolean_value (prop.can_seek);
         }
         builder.set_member_name ("pos");
         builder.add_int_value (prop.position);

--- a/src/mconnect/packet.vala
+++ b/src/mconnect/packet.vala
@@ -142,10 +142,18 @@ class Packet : GLib.Object {
         builder.add_string_value (device_id);
         builder.set_member_name ("deviceType");
         builder.add_string_value (device_type);
-        builder.set_member_name ("SupportedIncomingInterfaces");
-        builder.add_string_value (string.joinv (",", in_interfaces));
-        builder.set_member_name ("SupportedOutgoingInterfaces");
-        builder.add_string_value (string.joinv (",", out_interfaces));
+        builder.set_member_name ("incomingCapabilities");
+        builder.begin_array ();
+        foreach (string iface in in_interfaces) {
+            builder.add_string_value (iface);
+        }
+        builder.end_array ();
+        builder.set_member_name ("outgoingCapabilities");
+        builder.begin_array ();
+        foreach (string iface in out_interfaces) {
+            builder.add_string_value (iface);
+        }
+        builder.end_array ();
         builder.set_member_name ("protocolVersion");
         builder.add_int_value (PROTOCOL_VERSION);
         builder.end_object ();

--- a/src/mconnect/utils.vala
+++ b/src/mconnect/utils.vala
@@ -160,7 +160,7 @@ namespace Utils {
 
             // regex taken from SO
             // uncrustify breaks the regex, so *INDENT-OFF*
-			Regex r = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+,.~#?&\/=]*)/;
+			GLib.Regex r = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+,.~#?&\/=]*)/;
             // *INDENT-ON*
 
             MatchInfo mi;
@@ -180,7 +180,7 @@ namespace Utils {
                 debug ("no match");
             }
             return matches;
-        } catch (RegexError e) {
+        } catch (GLib.RegexError e) {
             warning ("failed to compile regex: %s", e.message);
             return {};
         }

--- a/src/mconnectctl/battery-iface.vala
+++ b/src/mconnectctl/battery-iface.vala
@@ -1,0 +1,30 @@
+/**
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * AUTHORS
+ * Maciek Borzecki <maciek.borzecki (at] gmail.com>
+ */
+namespace Mconnect {
+
+    [DBus (name = "org.mconnect.Device.Battery")]
+    public interface BatteryIface : Object {
+
+        public abstract uint level {
+            owned get;
+        }
+        public abstract bool charging {
+            owned get;
+        }
+    }
+}

--- a/src/mconnectctl/main.vala
+++ b/src/mconnectctl/main.vala
@@ -66,6 +66,7 @@ namespace Mconnect {
   list-devices         List devices
   allow-device <path>  Allow device
   show-device <path>   Show device details
+  show-battery <path>   Show device battery & charging
 
   share-url <path> <url>   Share URL with device
   share-text <path> <text>  Share text with device
@@ -94,6 +95,7 @@ namespace Mconnect {
                 Command ("list-devices", 0, cl.cmd_list_devices),
                 Command ("allow-device", 1, cl.cmd_allow_device),
                 Command ("show-device", 1, cl.cmd_show_device),
+                Command ("show-battery", 1, cl.cmd_show_battery),
                 Command ("share-url", 2, cl.cmd_share_url),
                 Command ("share-text", 2, cl.cmd_share_text),
                 Command ("share-file", 2, cl.cmd_share_file),
@@ -136,6 +138,7 @@ namespace Mconnect {
                     }
 
                     debug ("running callback");
+                    debug("TEST");
                     return cmden.clbk (command_args);
                 }
             }
@@ -254,6 +257,18 @@ namespace Mconnect {
             });
         }
 
+        private int cmd_show_battery(string[] args) {
+            debug("DEBUG_0");
+            return checked_dbus_call (() => {
+                var bt = get_battery (new ObjectPath (args[0]));
+
+                stdout.printf ("Level: %u\n" +
+                               "Charging: %d\n",
+                               bt.level,
+                               bt.charging);
+                return 0;
+            });
+        }
         private delegate int CheckDBusCallFunc () throws Error;
 
         /**
@@ -320,6 +335,18 @@ namespace Mconnect {
          * @return interface or null
          */
         private DeviceIface ? get_device (ObjectPath path) throws IOError {
+            return get_mconnect_obj_proxy (path);
+        }
+
+        /**
+         * get_device:
+         * @path device object path
+         *
+         * Obtain DBus interface to Device.Battery
+         *
+         * @return interface or null
+         */
+        private BatteryIface ? get_battery (ObjectPath path) throws IOError {
             return get_mconnect_obj_proxy (path);
         }
 


### PR DESCRIPTION
mconnect wouldn't start when spotifyd was auto-started. So I added handling for such cases here and opened an  #issue(https://github.com/Spotifyd/spotifyd/issues/921) in spotifyd for a more permanent fix. 