### PR TITLE
Do not crash if display is unavailable

### DIFF
--- a/src/mconnect/main.vala
+++ b/src/mconnect/main.vala
@@ -19,10 +19,10 @@ public static int main (string[] args) {
     var app = new Mconn.Application ();
 
     // needed for mousepad protocol handler
-    Gdk.init (ref args);
+    Gdk.init_check (ref args);
 
     // needed for clipboard sharing
-    Gtk.init (ref args);
+    Gtk.init_check (ref args);
 
     return app.run (args);
 }


### PR DESCRIPTION
This allows running mconnect when a display is unavailable, e.g., when running as a systemd user service.

mconnect will output a warning, but will not crash.

```patch
--- output-with-display	2021-06-06 05:12:29.000000000 +0000
+++ output-without-display	2021-06-06 05:12:29.000000000 +0000
@@ -1,5 +1,9 @@
+Unable to init server: Could not connect: Connection refused
+Unable to init server: Could not connect: Connection refused
 ** Message: 00:00:00.000: config.vala:58: loaded configuration from /home/selurvedu/.config/mconnect/mconnect.conf
 
+** (mconnect:0): WARNING **: 00:00:00.000: mousepad.vala:41: failed to obtain display
+
 ** (mconnect:0): WARNING **: 00:00:00.000: devicemanager.vala:218: no handler for capability kdeconnect.runcommand
 
 ** (mconnect:0): WARNING **: 00:00:00.000: devicemanager.vala:218: no handler for capability kdeconnect.sftp.request
```

Of course, things like clipboard sharing and mouse control are not going to work, but sending files, forwarding notifications from phone, controlling media, etc. will work.