### PR TITLE
Addresses https://github.com/bboozzoo/mconnect/issues/53

### DIFF
--- a/src/mconnect/devicechannel.vala
+++ b/src/mconnect/devicechannel.vala
@@ -228,14 +228,16 @@ class DeviceChannel : Object {
         string to_send = pkt.to_string () + "\n";
         debug ("send data: %s", to_send);
 
-        GLib.assert (this._dout != null);
-
-        try {
-            this._dout.put_string (to_send);
-        } catch (IOError e) {
-            warning ("failed to send message: %s", e.message);
-            // TODO disconnect?
-        }
+	if (this._dout != null) {
+	        try {
+	            this._dout.put_string (to_send);
+	        } catch (IOError e) {
+	            warning ("failed to send message: %s", e.message);
+	            // TODO disconnect?
+	        }
+	} else {
+            warning ("not connected to: %s", this._isa.address.to_string ());
+	}
     }
 
     /**


### PR DESCRIPTION
This prevents the server from crashing when the mpris plugin tries to talk to devices that aren't (yet) connected.

On the one hand, server processes should be as robust as possible and try to recover; in that spirit, my patch prevents the server from segfaulting when a device isn't present. However, the root cause -- that the mpris plugin may be incorrectly propegating messages -- is not addressed. On the other-other hand, I don't know if it shouldn't be propegating messages; probably, the bestest, correctest fix would be to make mconnect smart enough to not try to send messages to devices that aren't connected, whether or not plugins ask for it, but that's a much bigger change. And, as I initially stated, philisophically, having servers that recover gracefully when they encounter error states is preferable, so this is at least a necessary, if not sufficient, fix.